### PR TITLE
Do not force source recomputation

### DIFF
--- a/src/libadalang-gpr2_provider.adb
+++ b/src/libadalang-gpr2_provider.adb
@@ -2,7 +2,7 @@
 --                                                                          --
 --                                Libadalang                                --
 --                                                                          --
---                       Copyright (C) 2021, AdaCore                        --
+--                     Copyright (C) 2021-2022, AdaCore                     --
 --                                                                          --
 -- Libadalang is free software;  you can redistribute it and/or modify  it  --
 -- under terms of the GNU General Public License  as published by the Free  --
@@ -144,9 +144,6 @@ package body Libadalang.GPR2_Provider is
    begin
       --  If no project was given, try to run the partitionner
 
-      Tree.Invalidate_Sources;
-      Tree.Update_Sources (Stop_On_Error => False, With_Runtime => True);
-
       if not Actual_Project.Is_Defined then
          declare
             Result   : LAL.Unit_Provider_Reference;
@@ -241,9 +238,6 @@ package body Libadalang.GPR2_Provider is
    begin
       Trace.Increase_Indent
         ("Trying to partition " & String (Tree.Root_Project.Name));
-
-      Tree.Invalidate_Sources;
-      Tree.Update_Sources (Stop_On_Error => False, With_Runtime => True);
 
       if Tree.Root_Project.Kind = K_Aggregate then
 

--- a/src/libadalang-gpr2_provider.ads
+++ b/src/libadalang-gpr2_provider.ads
@@ -36,14 +36,6 @@ with Libadalang.Analysis;
 
 package Libadalang.GPR2_Provider is
 
-   --  In order for unit names to be resolved the sources of project tree
-   --  need to be computed, so GPR2.Tree.Update_Sources needs to be called
-   --  before creating a unit provider. In addition, in order to resolve
-   --  runtime unit names corresponding project tree sources need to be updated
-   --  with runtime files included: With_Runtime parameter of Update_Sources
-   --  needs to be set to True. Source recomputation is a costly operation and
-   --  unit provider does not enforce it to avoid unnecessary recomputation.
-
    package LAL renames Libadalang.Analysis;
 
    Trace : constant GNATCOLL.Traces.Trace_Handle := GNATCOLL.Traces.Create
@@ -74,6 +66,14 @@ package Libadalang.GPR2_Provider is
    --
    --  The project pointed to by ``Tree`` must outlive the returned unit file
    --  providers, and it is up to callers to deallocate ``Tree`` itself.
+   --
+   --  In order for unit names to be resolved the sources of project tree
+   --  need to be computed, so GPR2.Tree.Update_Sources needs to be called
+   --  before creating a unit provider. In addition, in order to resolve
+   --  runtime unit names corresponding project tree sources need to be updated
+   --  with runtime files included: With_Runtime parameter of Update_Sources
+   --  needs to be set to True. Source recomputation is a costly operation and
+   --  unit provider does not enforce it to avoid unnecessary recomputation.
 
    Unsupported_View_Error : exception;
    --  See the ``Create_Project_Unit_Provider`` function
@@ -88,10 +88,11 @@ package Libadalang.GPR2_Provider is
    --  ``Unsupported_View_Error`` exception if that project aggregates more
    --  than one project in its closure.
    --
-   --  If Project is not provided, run ``Create_Project_Unit_Providers``: if it
-   --  returns only one provider, return it, otherwise raise an
+   --  If Project is not provided, run ``Create_Project_Unit_Providers``:
+   --  if it returns only one provider, return it, otherwise raise an
    --  ``Unsupported_View_Error`` exception.
    --
-   --  Tree must outlive the returned unit file provider.
+   --  Tree must outlive the returned unit file provider and project tree
+   --  sources must be initialized (see ``Create_Project_Unit_Providers``).
 
 end Libadalang.GPR2_Provider;

--- a/src/libadalang-gpr2_provider.ads
+++ b/src/libadalang-gpr2_provider.ads
@@ -2,7 +2,7 @@
 --                                                                          --
 --                                Libadalang                                --
 --                                                                          --
---                       Copyright (C) 2021, AdaCore                        --
+--                     Copyright (C) 2021-2022, AdaCore                     --
 --                                                                          --
 -- Libadalang is free software;  you can redistribute it and/or modify  it  --
 -- under terms of the GNU General Public License  as published by the Free  --
@@ -35,6 +35,14 @@ with Libadalang.Analysis;
 --  GPR2 project library.
 
 package Libadalang.GPR2_Provider is
+
+   --  In order for unit names to be resolved the sources of project tree
+   --  need to be computed, so GPR2.Tree.Update_Sources needs to be called
+   --  before creating a unit provider. In addition, in order to resolve
+   --  runtime unit names corresponding project tree sources need to be updated
+   --  with runtime files included: With_Runtime parameter of Update_Sources
+   --  needs to be set to True. Source recomputation is a costly operation and
+   --  unit provider does not enforce it to avoid unnecessary recomputation.
 
    package LAL renames Libadalang.Analysis;
 

--- a/testsuite/tests/project_unit_provider/main.adb
+++ b/testsuite/tests/project_unit_provider/main.adb
@@ -5,9 +5,6 @@
 with Ada.Exceptions;
 with Ada.Text_IO; use Ada.Text_IO;
 
---  with GNATCOLL.Projects; use GNATCOLL.Projects;
---  with GNATCOLL.VFS;      use GNATCOLL.VFS;
-
 with GPR2.Path_Name;
 with GPR2.Project.Tree;
 with GPR2.Context;
@@ -16,7 +13,6 @@ with GPR2.Project.View; use GPR2.Project.View;
 with Libadalang.Analysis;         use Libadalang.Analysis;
 with Libadalang.Common;           use Libadalang.Common;
 with Libadalang.Iterators;        use Libadalang.Iterators;
---  with Libadalang.Project_Provider; use Libadalang.Project_Provider;
 with Libadalang.GPR2_Provider; use Libadalang.GPR2_Provider;
 
 with GNAT.Traceback.Symbolic;
@@ -48,6 +44,7 @@ procedure Main is
       Tree.Load_Autoconf
         (Filename => GPR2.Path_Name.Create_File (File),
          Context  => GPR2.Context.Empty);
+      Tree.Update_Sources;
       if Project'Length > 0 then
          for V of Tree.Ordered_Views loop
             if V.Name = Project then
@@ -89,22 +86,14 @@ procedure Main is
 
 begin
    Try_Loading_Project ("unsupported_aggr.gpr");
---     Tree.Unload;
    Try_Loading_Project ("unsupported_aggr.gpr", "unsupported_aggr");
---     Tree.Unload;
    Try_Loading_Project ("unsupported_aggr.gpr", "p");
---     Tree.Unload;
    Try_Loading_Project ("supported_no_conflict.gpr");
---     Tree.Unload;
    Try_Loading_Project ("supported_simple_aggr.gpr");
---     Tree.Unload;
    Try_Loading_Project ("supported_simple_aggr.gpr", "supported_simple_aggr");
---     Tree.Unload;
    Try_Loading_Project ("supported_chained_aggr.gpr");
---     Tree.Unload;
    Try_Loading_Project ("supported_chained_aggr.gpr",
                         "supported_chained_aggr");
---     Tree.Unload;
 
    declare
       Ctx  : constant Analysis_Context :=


### PR DESCRIPTION
This will speed up the creation of unit providers, since
tools using them will have to compute the sources at some
point anyway.
Put corresponding explanatory comment at the beginning of the spec.

TN: V209-021